### PR TITLE
0, false and "" as defaults, null disallowed

### DIFF
--- a/scripts/cerberusValidationSchema
+++ b/scripts/cerberusValidationSchema
@@ -41,11 +41,9 @@ inputs:
           type: options
       example:
         required: true
-        nullable: true
         oneof:
         - type: number
         - type: string
-          nullable: true
         - type: boolean
         - type: list
 

--- a/scripts/climateMetrics/backwardVelocity.yml
+++ b/scripts/climateMetrics/backwardVelocity.yml
@@ -70,12 +70,12 @@ inputs:
     label: bbox coordinates
     description: coordinates of the bbox, in the order xmin, xmax, ymax, ymin.
     type: float[]
-    example: null
+    example: [-2316297,-1971146,1015207,1511916]
   buffer_box:
     label: buffer box
     description: buffer surronding box
     type: int
-    example: null
+    example: 0
   shapefile_path:
     label: shapefile path
     description: Path to a .shp file representing the extent.

--- a/scripts/climateMetrics/climateRarity.yml
+++ b/scripts/climateMetrics/climateRarity.yml
@@ -75,12 +75,12 @@ inputs:
     label: bbox coordinates
     description: coordinates of the bbox, in the order xmin, xmax, ymax, ymin.
     type: float[]
-    example: null
+    example: [-2316297,-1971146,1015207,1511916]
   buffer_box:
     label: buffer box
     description: buffer surronding box
     type: int
-    example: null
+    example: 0
   shapefile_path:
     label: shapefile path
     description: Path to a .shp file representing the extent.

--- a/scripts/climateMetrics/forwardVelocity.yml
+++ b/scripts/climateMetrics/forwardVelocity.yml
@@ -70,12 +70,12 @@ inputs:
     label: bbox coordinates
     description: coordinates of the bbox, in the order xmin, xmax, ymax, ymin.
     type: float[]
-    example: null
+    example: [-2316297,-1971146,1015207,1511916]
   buffer_box:
     label: buffer box
     description: buffer surronding box
     type: int
-    example: null
+    example: 0
   shapefile_path:
     label: shapefile path
     description: Path to a .shp file representing the extent.

--- a/scripts/climateMetrics/localVelocity.yml
+++ b/scripts/climateMetrics/localVelocity.yml
@@ -70,12 +70,12 @@ inputs:
     label: bbox coordinates
     description: coordinates of the bbox, in the order xmin, xmax, ymax, ymin.
     type: float[]
-    example: null
+    example: [-2316297,-1971146,1015207,1511916]
   buffer_box:
     label: buffer box
     description: buffer surronding box
     type: int
-    example: null
+    example: 0
   shapefile_path:
     label: shapefile path
     description: Path to a .shp file representing the extent.

--- a/ui/src/components/InputFileWithExample.js
+++ b/ui/src/components/InputFileWithExample.js
@@ -24,7 +24,7 @@ export function InputFileWithExample({defaultValue, metadata}) {
         let input = metadata.inputs[inputKey];
         if (input) {
           const example = input.example;
-          inputExamples[inputKey] = example ? example : "...";
+          inputExamples[inputKey] = example === undefined ? null : example;
         }
       });
     }

--- a/ui/src/components/PipelineEditor/ScriptDescriptionStore.js
+++ b/ui/src/components/PipelineEditor/ScriptDescriptionStore.js
@@ -22,7 +22,7 @@ export function fetchScriptDescription(descriptionFileLocation, callback) {
       console.error("Error loading " + descriptionFileLocation + ": ", error)
     } else {
       descriptions[descriptionFileLocation] = callbackData
-      callback(descriptions[descriptionFileLocation])
+      callback(callbackData)
     }
   });
 }


### PR DESCRIPTION
#330: Tested inputs examples with 0, false and "".
#363: Null examples not allowed for inputs. Prefer using 0, [], "", etc.