### PR TITLE
Python conda runner

### DIFF
--- a/.github/workflows/docker_runner-conda.yml
+++ b/.github/workflows/docker_runner-conda.yml
@@ -25,7 +25,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Extract metadata (tags, labels) for Docker, main branch
+    - name: Extract metadata (tags, labels) for Docker
       if: github.ref == 'refs/heads/main'
       id: metadata-main
       uses: docker/metadata-action@v4

--- a/.github/workflows/docker_runner-conda.yml
+++ b/.github/workflows/docker_runner-conda.yml
@@ -53,6 +53,6 @@ jobs:
         context: runners
         file: runners/conda-dockerfile
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.metadata-main.outputs.tags || steps.metadata-staging.outputs.tags }}
+        labels: ${{ steps.metadata-main.outputs.labels || steps.metadata-staging.outputs.labels }}
 

--- a/.github/workflows/docker_runner-julia.yml
+++ b/.github/workflows/docker_runner-julia.yml
@@ -50,6 +50,7 @@ jobs:
         context: runners
         file: runners/julia-dockerfile
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.metadata-main.outputs.tags || steps.metadata-staging.outputs.tags }}
+        labels: ${{ steps.metadata-main.outputs.labels || steps.metadata-staging.outputs.labels }}
+
 

--- a/.github/workflows/docker_runner-julia.yml
+++ b/.github/workflows/docker_runner-julia.yml
@@ -1,4 +1,4 @@
-name: Julia Runner, main branch
+name: Julia Runner
 
 on:
   workflow_dispatch:

--- a/runners/conda-dockerfile
+++ b/runners/conda-dockerfile
@@ -1,5 +1,4 @@
 FROM  condaforge/mambaforge
-
 WORKDIR /data
 
 # Setting Time zone (necessary to install cmake, + will persist at runtime)

--- a/runners/conda-dockerfile
+++ b/runners/conda-dockerfile
@@ -25,6 +25,7 @@ RUN chmod 777 /.condarc
 # Permissions cannot be defined at mount time, hence we create empty folder with the appropriate permissions.
 RUN mkdir /.cache && mkdir /.cache/conda && chmod a+w /.cache/conda
 RUN mkdir /.conda && chmod a+w /.conda
+RUN mkdir /.config && chmod a+w /.config
 RUN mkdir /r-libs-user && chmod a+w /r-libs-user
 RUN mkdir /conda-env-yml && chmod a+w /conda-env-yml
 

--- a/runners/conda-dockerfile
+++ b/runners/conda-dockerfile
@@ -56,4 +56,8 @@ RUN bash --login -c "mamba activate rbase; R -e 'install.packages(c(\"Coordinate
 RUN bash --login -c "mamba activate rbase; R -e 'devtools::install_github(\"ReseauBiodiversiteQuebec/stac-catalogue\")'"
 RUN bash --login -c "mamba activate rbase; R -e 'devtools::install_github(\"connectscape/Makurhini\")'"
 
+ADD ./python-environment.yml /data/python-environment.yml
+RUN mamba env create -f /data/python-environment.yml
+RUN chmod -R 777 /opt/conda/pkgs/cache
+
 RUN date +"%Y-%m-%d %R" > /version.txt

--- a/runners/conda-dockerfile
+++ b/runners/conda-dockerfile
@@ -1,9 +1,6 @@
 FROM  condaforge/mambaforge
 
-ADD ./r-environment.yml /data/r-environment.yml
-
 WORKDIR /data
-
 
 # Setting Time zone (necessary to install cmake, + will persist at runtime)
 ENV TZ=Etc/UTC
@@ -39,12 +36,8 @@ RUN echo 'eval "$(conda shell.bash hook)"; source /opt/conda/etc/profile.d/mamba
 # See https://stackoverflow.com/a/74017557/3519951
 RUN sed -e '/[ -z "$PS1" ] && return/s/^/#/g' -i /root/.bashrc
 
+ADD ./r-environment.yml /data/r-environment.yml
 RUN mamba env create -f /data/r-environment.yml
-
-# Hide "error libmamba Could not open lockfile '/opt/conda/pkgs/cache/cache.lock'" when installing manually with non-root user
-# That error would not prevent the correct installation, but it looked like it to the user.
-RUN chmod -R 777 /opt/conda/pkgs/cache
-
 
 ## ADD CRAN PACKAGES HERE (for packages not found in anaconda.org)
 RUN bash --login -c "mamba activate rbase; R -e 'install.packages(c(\"CoordinateCleaner\", \
@@ -58,6 +51,9 @@ RUN bash --login -c "mamba activate rbase; R -e 'devtools::install_github(\"conn
 
 ADD ./python-environment.yml /data/python-environment.yml
 RUN mamba env create -f /data/python-environment.yml
+
+# Hide "error libmamba Could not open lockfile '/opt/conda/pkgs/cache/cache.lock'" when installing manually with non-root user
+# That error would not prevent the correct installation, but it looked like it to the user.
 RUN chmod -R 777 /opt/conda/pkgs/cache
 
 RUN date +"%Y-%m-%d %R" > /version.txt

--- a/runners/python-environment.yml
+++ b/runners/python-environment.yml
@@ -1,0 +1,5 @@
+name: pythonbase
+channels:
+  - conda-forge
+dependencies:
+  - pystac


### PR DESCRIPTION
Python environment "pythonbase" integrated to Conda runner.
+ fix GH Action reference

Currently on staging. This can be tested by 1) changing the image in `compose.env.yml` like this:
``` yml
services:
  runner-conda:
    image: geobon/bon-in-a-box:runner-conda-python-conda-staging
[...]
```
2) Running `./server-up.sh staging`

Make sure you have stable connexion, downloading the runner is 2.7GB.
**Once tested, make sure to revert `compose.env.yml` !**

Server-side PR: https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/pull/169
Closes #140