### PR TITLE
Add lifecycle to deprecated script

### DIFF
--- a/pipelines/helloWorld.json
+++ b/pipelines/helloWorld.json
@@ -53,6 +53,9 @@
   "metadata": {
     "name": "Hello World pipeline",
     "description": "This very simple pipeline shows how to connect a single script to a single output.\nThe input of the script is left blank, thus becoming a pipeline input.",
+    "lifecycle" : {
+      "status": "example"
+    },
     "author": [
       {
         "name": "Jean-Michel Lord",

--- a/scripts/data/getObservations.yml
+++ b/scripts/data/getObservations.yml
@@ -1,6 +1,9 @@
 script: getObservations.R
-name: GBIF Observations < 100 000 (DEPRECATED - Please use script getGBIFObservations instead)
+name: GBIF Observations < 100 000 (DEPRECATED)
 description: "This script gets observations from GBIF database, using the package RGIF."
+lifecycle:
+  status: "deprecated"
+  message: Please use script "GBIF Observations from Download API" (getGBIFObservations) instead
 external_link: https://github.com/ropensci/rgbif
 author:
   - name: Sarah Valentin

--- a/scripts/helloWorld/helloJulia.yml
+++ b/scripts/helloWorld/helloJulia.yml
@@ -4,6 +4,8 @@ author:
   - name: Jean-Michel Lord
     identifier: https://orcid.org/0009-0007-3826-1125
 description: "This sample script shows how it works in Julia."
+lifecycle:
+  status: example
 external_link: https://github.com/GEO-BON/biab-2.0
 inputs:
 outputs:

--- a/scripts/helloWorld/helloPython.yml
+++ b/scripts/helloWorld/helloPython.yml
@@ -1,10 +1,12 @@
 script: helloPython.py
 name: Python Example
-author: 
+author:
   - name: Jean-Michel Lord
     identifier: https://orcid.org/0009-0007-3826-1125
 license: CC0
 description: "Sample python script that increments a number."
+lifecycle:
+  status: example
 timeout: 1
 inputs:
   some_int:

--- a/scripts/helloWorld/helloR.yml
+++ b/scripts/helloWorld/helloR.yml
@@ -6,6 +6,8 @@ author:
     identifier: https://orcid.org/0009-0007-3826-1125
   - name: Guillaume Larocque
 description: "This sample script shows how it works. Remember that you can use **MarkDown** to style descriptions and add [links](http://boninabox.geobon.org)."
+lifecycle:
+  status: example
 external_link: https://github.com/GEO-BON/biab-2.0
 inputs:
   raster:

--- a/scripts/helloWorld/helloShell.yml
+++ b/scripts/helloWorld/helloShell.yml
@@ -4,6 +4,8 @@ author:
   - name: Jean-Michel Lord
     identifier: https://orcid.org/0009-0007-3826-1125
 description: "Sample shell script that outputs a number."
+lifecycle:
+  status: example
 outputs:
   a_number:
     label: A number


### PR DESCRIPTION
when the pull request on the [lifecycle of pipelines and scripts](https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/pull/239) feature gets merged, the new lifecycle field can be used in the script and pipeline files