### PR TITLE
Add orcid url author

### DIFF
--- a/pipelines/zonal_statistics.json
+++ b/pipelines/zonal_statistics.json
@@ -359,7 +359,7 @@
       {
         "name": "Jory Griffith",
         "email": "jory.griffith@mcgill.ca",
-        "identifier": "0000-0001-6020-6690"
+        "identifier": "https://orcid.org/0000-0001-6020-6690"
       }
     ],
     "license": "CC-BY",


### PR DESCRIPTION
Author's orcid did not lead to the orcid.org website and was routed to a non-existant internal path