### PR TITLE
add docker dep to load EEZs

### DIFF
--- a/runners/conda/conda-dockerfile
+++ b/runners/conda/conda-dockerfile
@@ -13,7 +13,7 @@ ENV TZ=Etc/UTC
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -ex; \
     apt-get update; \
-    apt-get install -y --no-install-recommends cmake psmisc; \
+    apt-get install -y --no-install-recommends cmake psmisc librdf0-dev; \
     apt-get clean all;
 
 ## Mamba installation


### PR DESCRIPTION
Add dependency to docker to try and successfully install the mregions2 package in R for loading EEZs for OHI