### PR TITLE
Fixing GBIF API because usageKey changed to "usage" and "key" separately

### DIFF
--- a/scripts/data/getGBIFObservations/gbif_api.py
+++ b/scripts/data/getGBIFObservations/gbif_api.py
@@ -24,7 +24,7 @@ def gbif_api_dl(splist=[], bbox=[], years=[1980, 2022], outfile=('out.csv')):
 	for x in splist:
 		print(x)
 		try:
-			keys.append(species.name_backbone(x)['usageKey'])
+			keys.append(species.name_backbone(x)['usage']['key'])
 		except:
 			print(f"Couldn't find {x}")
 			continue


### PR DESCRIPTION
Fixing GBIF API because usageKey changed to "usage" and "key" separately
