### PR TITLE
Fixing small error

### DIFF
--- a/scripts/data/load_polygons.R
+++ b/scripts/data/load_polygons.R
@@ -39,12 +39,12 @@ if (!is.null(val_country) && length(val_country) > 0 && !(is.atomic(val_country)
 # Path for polygon
 if (country) { # if there is a country or region input
     if (is.null(input$country_region_bbox$region)) {
-    name <- gsub(" ", "_", input$country_region_bbox$country$englishName)
+        name <- gsub(" ", "_", input$country_region_bbox$country$englishName)
     } else {
-    name <- gsub(" ", "_", input$country_region_bbox$region$regionName)
+        name <- gsub(" ", "_", input$country_region_bbox$region$regionName)
     }
 } else {
-     name <- "bbox" # or we just call it bbox
+    name <- "bbox" # or we just call it bbox
 }
 
 
@@ -101,8 +101,6 @@ if (input$polygon_type == "Country or region") {
                 st_set_crs(4326)
             geo_data_sf$fid <- as.integer(geo_data_sf$fid)
         }
-
-        
     } else { # custom bounding box
         print(sprintf("Loading region polygon for custom bounding box: %s", paste(input$country_region_bbox$bbox, collapse = ", ")))
         con <- dbConnect(duckdb())
@@ -166,15 +164,15 @@ if (input$polygon_type == "WDPA") {
     coord <- st_crs(crs_input)
     # Load the CRS object
     if (!is.null(input$buffer) && input$buffer > 0) {
-  # Check for inconsistencies between CRS type and resolution
-  if (st_is_longlat(coord) && input$buffer > 1) {
-    biab_error_stop("CRS is in degrees and buffer distance is in meters.")
-  }
+        # Check for inconsistencies between CRS type and resolution
+        if (st_is_longlat(coord) && input$buffer > 1) {
+            biab_error_stop("CRS is in degrees and buffer distance is in meters.")
+        }
 
-  if (st_is_longlat(coord) == FALSE && input$buffer < 1) {
-    biab_error_stop("CRS is in meters and buffer distance is in degrees.")
-  }
-}
+        if (st_is_longlat(coord) == FALSE && input$buffer < 1) {
+            biab_error_stop("CRS is in meters and buffer distance is in degrees.")
+        }
+    }
 
     # If user selected a country, we will use its polygon to crop the WDPA data
     if (country) {


### PR DESCRIPTION
There was an error where it was giving an error when the transboundary distance was 0. Fixed so it only triggers the "transboundary distance is in degrees and crs is in meters" error when the input distance is greater than 0
