### PR TITLE
Hardcoding duckdb package version (temporary)

### DIFF
--- a/scripts/data/load_polygons.R
+++ b/scripts/data/load_polygons.R
@@ -4,9 +4,10 @@ library(dplyr)
 if (!require("duckdbfs")) {
     install.packages("duckdbfs")
 }
-if (!require("duckspatial")) {
-    install.packages("duckspatial")
+if (!require("duckspatial") || packageVersion("duckspatial") != "0.9.0") {
+    remotes::install_github("Cidree/duckspatial@v0.9.0")
 }
+
 library(duckdbfs)
 library(duckspatial)
 

--- a/scripts/data/load_polygons.yml
+++ b/scripts/data/load_polygons.yml
@@ -41,7 +41,7 @@ conda:
   dependencies:
     - r-arrow
     - r-rjson
-    - r-duckdb
+    - r-duckdb=1.4.4
     - r-sf
     - r-dplyr
     - r-stringi
@@ -50,3 +50,4 @@ conda:
     - r-dbplyr
     - r-fs
     - r-uuid
+    - r-remotes


### PR DESCRIPTION
This pull request is meant to pin duckdb version 1.4.4 while we wait for duckspatial to be updated and functional with the new version of duckdb (1.5.0)
