### PR TITLE
Adding core tags to scripts

### DIFF
--- a/scripts/SDM/extentToBbox.yml
+++ b/scripts/SDM/extentToBbox.yml
@@ -4,7 +4,8 @@ description: "This script convert a spatial object (a shapefile, a table of coor
 author:
   - name: Sarah Valentin
     identifier: https://orcid.org/0000-0002-9028-681X
-
+lifecycle:
+  status: core
 inputs:
   source:
     label: source
@@ -51,20 +52,20 @@ inputs:
     type: float
     example: 1511916
   path_shp:
-    label: shapefile path 
+    label: shapefile path
     description: string, path to a shapefile
     type: application/dbf
     example: "/scripts/SDM/extentToBbox_extent.shp"
   proj_from:
-    label: input projection system 
+    label: input projection system
     description: string, projection of the input spatial object
     type: text
     example: "EPSG:6623"
   proj_to:
-    label: output bbox projection system 
+    label: output bbox projection system
     description: string, projection of output bbox
     type: text
-    example: "EPSG:6623"  
+    example: "EPSG:6623"
 
 outputs:
   bbox:

--- a/scripts/SDM/loadExtent.yml
+++ b/scripts/SDM/loadExtent.yml
@@ -5,12 +5,13 @@ author:
   - name: Sarah Valentin
     identifier: https://orcid.org/0000-0002-9028-681X
 external_link: https://googledrive.tidyverse.org/
-
+lifecycle:
+  status: core
 inputs:
   url:
     label: link
     description: String, link to the file.
-    type: text 
+    type: text
     example: "https://drive.google.com/file/d/1KKFOBKInnroe452Y7P8uu-h42QbHM6ff/view?usp=sharing"
   shp_name:
     label: shapefile name
@@ -20,6 +21,6 @@ inputs:
 outputs:
   extent:
     label: extent
-    description: Shape file representing the study extent 
+    description: Shape file representing the study extent
     type: application/dbf
     example: /output/studyExtent/studyExtent_R/9ab734795ba757bdabb32ae6708e18d1/study_extent.shp

--- a/scripts/binaryLayer/binaryLayer.yml
+++ b/scripts/binaryLayer/binaryLayer.yml
@@ -2,6 +2,8 @@ script: binaryLayer.R
 name: Binary Layer
 author:
   - name: Juan Zuloaga
+lifecycle:
+  status: core
 description: This script creates a binary layer from another layer using a threshold value (e.g.land cover class proportion above 0.8).
 inputs:
   lc_classes:

--- a/scripts/data/GBIFHeatmapFromSTAC.yml
+++ b/scripts/data/GBIFHeatmapFromSTAC.yml
@@ -6,7 +6,8 @@ description: |
 author:
   - name: Guillaume Larocque
     identifier: https://orcid.org/0000-0002-5967-9156
-
+lifecycle:
+  status: core
 inputs:
   taxa:
     label: Taxa

--- a/scripts/data/cleanWDPA.yml
+++ b/scripts/data/cleanWDPA.yml
@@ -13,7 +13,7 @@ author:
     email: jory.griffith@mcgill.ca
     identifier: https://orcid.org/0000-0001-6020-6690
 lifecycle:
-  status: reviewed
+  status: core
 inputs:
   study_area_polygon:
     label: Study area polygon

--- a/scripts/data/getGBIFObservations/getGBIFObservations.yml
+++ b/scripts/data/getGBIFObservations/getGBIFObservations.yml
@@ -5,7 +5,7 @@ author:
   - name: Guillaume Larocque
     identifier: https://orcid.org/0000-0002-5967-9156
 lifecycle:
-  status: in_review
+  status: core
 
 inputs:
   taxa:

--- a/scripts/data/getOBISObservations.yml
+++ b/scripts/data/getOBISObservations.yml
@@ -5,6 +5,8 @@ author:
   - name: Jory Griffith
     email: jory.griffith@mcgill.ca
     identifier: https://orcid.org/0000-0001-6020-6690
+lifecycle:
+  status: core
 inputs:
   species_name:
     label: Species name
@@ -16,12 +18,12 @@ inputs:
     description: Bounding box for the area to pull OBIS points
     type: bboxCRS
     example: NULL
-  study_area: 
+  study_area:
     label: Polygon of study area
     description: Polygon of study area for which you want to pull OBIS points
     type: application/geopackage+sqlite3
     example: null
-  start_date: 
+  start_date:
     label: Start date
     description: Start date for the occurences in YYYY-MM-DD format (leave blank for all dates)
     type: text
@@ -36,23 +38,23 @@ inputs:
     description: Mininum depth in meters for occurences (leave blank for no minimum depth)
     type: int
     example: null
-  max_depth: 
+  max_depth:
     label: Maximum depth
     description: Maximum depth in meters for occurences (leave blank for no maximum depth)
     type: int
     example: null
 outputs:
-  occurrences: 
+  occurrences:
     label: OBIS Occurrences
     description: CSV of OBIS occurrences
     type: text/csv
 conda:
-  channels: 
+  channels:
     - conda-forge
     - r
-  dependencies: 
+  dependencies:
     - r-robis
     - r-sf
     - r-dplyr
     - r-rjson
-  
+

--- a/scripts/data/getObservationsBiodiversiteQuebecAtlas.yml
+++ b/scripts/data/getObservationsBiodiversiteQuebecAtlas.yml
@@ -4,7 +4,8 @@ description: Load observations from [Biodiversité Québec's Atlas](https://biod
 author:
   - name: Guillaume Larocque
     identifier: https://orcid.org/0000-0002-5967-9156
-
+lifecycle:
+  status: core
 inputs:
   taxa:
     description: Array of taxa values

--- a/scripts/data/getRangeMap.yml
+++ b/scripts/data/getRangeMap.yml
@@ -6,6 +6,8 @@ author:
     identifier: https://orcid.org/0000-0003-4024-9268
   - name: Guillaume Larocque
     identifier: https://orcid.org/0000-0002-5967-9156
+lifecycle:
+  status: core
 license: CC BY
 external_link: https://github.com/GEO-BON/biab-2.0/tree/main/scripts/SHI
 inputs:

--- a/scripts/data/loadChelsaProjections.yml
+++ b/scripts/data/loadChelsaProjections.yml
@@ -1,9 +1,11 @@
 script: loadChelsaProjections.R
 name: Load CHELSA climate projections
-description: 
+description:
   This script loads the CHELSA climate projections
 author:
   - name: Juan Zuloaga
+lifecycle:
+  status: core
 inputs:
   bbox_crs:
     label: Bounding box and CRS
@@ -14,17 +16,17 @@ inputs:
     label: Shared socioeconomic pathways
     description: Shared socioeconomic pathways ([more info here](see https://en.wikipedia.org/wiki/Shared_Socioeconomic_Pathways))
     type: options
-    options: 
+    options:
       - ssp126
       - ssp370
       - ssp585
     example: ssp126
   spatial_res:
     label: Spatial resolution output
-    description: Pixel size of the output raster in the same units as the coordinate reference system (meters or degrees). 
+    description: Pixel size of the output raster in the same units as the coordinate reference system (meters or degrees).
     type: float
-    example: 0.008 
-  variable: 
+    example: 0.008
+  variable:
     label: Climate variable
     description: Chelsa climte variable for projection. See a list of variables [here](https://chelsa-climate.org/wp-admin/download-page/CHELSA_tech_specification.pdf) in section 5.
     type: text
@@ -40,7 +42,7 @@ inputs:
     description: Period for climate projection, start year to end year
     type: options
     options:
-      - 2011-2040 
+      - 2011-2040
       - 2041-2070
       - 2071-2100
     example: 2041-2070

--- a/scripts/data/loadFromStac.yml
+++ b/scripts/data/loadFromStac.yml
@@ -5,7 +5,7 @@ author:
   - name: Guillaume Larocque
     identifier: https://orcid.org/0000-0002-5967-9156
 lifecycle:
-  status: in_review
+  status: core
 inputs:
   bbox_crs:
     label: Bounding box and CRS

--- a/scripts/data/load_polygons.yml
+++ b/scripts/data/load_polygons.yml
@@ -7,6 +7,8 @@ author:
   - name: Jory Griffith
     email: jory.griffith@mcgill.ca
     identifier: https://orcid.org/0000-0001-6020-6690
+lifecycle:
+  status: core
 inputs:
   polygon_type:
     label: Polygon type

--- a/scripts/data/obsToHeatmap.yml
+++ b/scripts/data/obsToHeatmap.yml
@@ -3,7 +3,8 @@ name: Observations to Heatmap
 description: "Converts occurrence points to raster, conforming to resolution and projection of the predictors raster."
 author:
   - name: Dat Nguyen
-
+lifecycle:
+  status: core
 inputs:
   presence:
     label: presence

--- a/scripts/filtering/cleanCoordinates.yml
+++ b/scripts/filtering/cleanCoordinates.yml
@@ -13,7 +13,7 @@ references:
   - text: Zizka A, Silvestro D, Andermann T, Azevedo J, Duarte Ritter C, Edler D, Farooq H, Herdean A, Ariza M, Scharn R, Svanteson S, Wengtrom N, Zizka V & Antonelli A (2019) CoordinateCleaner, standardized cleaning of occurrence records from biological collection databases. Methods in Ecology and Evolution, 10(5):744-751
     doi: https://doi.org/10.1111/2041-210X.13152
 lifecycle:
-  status: in_review
+  status: core
 
 inputs:
   presence:


### PR DESCRIPTION
Using the lifecycle tag "core" for scripts that are meant to be used across many pipelines. These scripts will thus not undergo any peer review explicitly, but rather be part of the core scripts within BIAB.