### PR TITLE
fixing load from STAC resolution and CRS mismatch error

### DIFF
--- a/pipelines/BII/BII.json
+++ b/pipelines/BII/BII.json
@@ -405,10 +405,10 @@
       "weight": 2
     },
     "data>loadFromStac.yml@56|spatial_res": {
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long).\nLeave blank to use the original spatial resolution of the layers. If left blank, CRS must be EPSG:4326.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). If this is left blank it will use the native resolution of the rasters. If the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled using method \"near\".",
       "label": "Spatial resolution (optional)",
       "type": "float",
-      "example": null,
+      "example": 0.00833,
       "weight": 3
     },
     "pipeline@63": {

--- a/pipelines/BILBI_pipelines/beri_pipeline.json
+++ b/pipelines/BILBI_pipelines/beri_pipeline.json
@@ -477,9 +477,9 @@
     },
     "pipeline@19": {
       "label": "Spatial resolution",
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long).\n\nLeave blank to use the original spatial resolution of the layers. If left blank, CRS must be EPSG:4326.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "float",
-      "example": null,
+      "example": 0.008833,
       "weight": 5
     },
     "pipeline@18": {

--- a/pipelines/BILBI_pipelines/bhi_pipeline.json
+++ b/pipelines/BILBI_pipelines/bhi_pipeline.json
@@ -495,9 +495,9 @@
     },
     "pipeline@19": {
       "label": "Spatial resolution (optional)",
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long).\n\nLeave blank to use the original spatial resolution of the layers. If left blank, CRS must be EPSG:4326.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "float",
-      "example": null,
+      "example": 0.008833,
       "weight": 5
     },
     "pipeline@18": {

--- a/pipelines/BILBI_pipelines/parc_pipeline.json
+++ b/pipelines/BILBI_pipelines/parc_pipeline.json
@@ -495,9 +495,9 @@
     },
     "pipeline@19": {
       "label": "Spatial resolution",
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long).\n\nLeave blank to use the original spatial resolution of the layers. If left blank, CRS must be EPSG:4326.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "float",
-      "example": null,
+      "example": 0.008833,
       "weight": 5
     },
     "pipeline@18": {

--- a/pipelines/SDM/SDM_BRT.json
+++ b/pipelines/SDM/SDM_BRT.json
@@ -785,7 +785,7 @@
     },
     "pipeline@128": {
       "label": "Spatial Resolution",
-      "description": "Integer, spatial resolution of the rasters in the same units as the chosen coordinate reference system (meters or degrees)",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method \"near\".",
       "type": "float",
       "example": 1000,
       "weight": 5

--- a/pipelines/SDM/SDM_ewlgcp.json
+++ b/pipelines/SDM/SDM_ewlgcp.json
@@ -938,7 +938,7 @@
     },
     "pipeline@128": {
       "label": "Spatial resolution",
-      "description": "Integer, spatial resolution of the rasters",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "float",
       "example": 1000,
       "weight": 8

--- a/pipelines/SDM/SDM_maxEnt.json
+++ b/pipelines/SDM/SDM_maxEnt.json
@@ -867,7 +867,7 @@
     },
     "pipeline@128": {
       "label": "spatial resolution",
-      "description": "Integer, spatial resolution of the rasters",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method \"near\"",
       "type": "float",
       "example": 1000,
       "weight": 4

--- a/pipelines/SHI/SHI_GFW.json
+++ b/pipelines/SHI/SHI_GFW.json
@@ -643,7 +643,7 @@
     },
     "pipeline@79": {
       "label": "Output spatial resolution",
-      "description": "Spatial resolution (in meters) for the output of the analysis.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "int",
       "example": 1000,
       "weight": 12

--- a/pipelines/SHI/SHS_GFW.json
+++ b/pipelines/SHI/SHS_GFW.json
@@ -527,7 +527,7 @@
     },
     "pipeline@79": {
       "label": "Spatial resolution",
-      "description": "Spatial resolution (in meters) for the analysis.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "type": "int",
       "example": 1000,
       "weight": 12

--- a/pipelines/landcover_percent.json
+++ b/pipelines/landcover_percent.json
@@ -210,10 +210,10 @@
       "weight": 5
     },
     "data>loadFromStac.yml@42|spatial_res": {
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nLeave blank to maintain the original spatial resolution of the layer.",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "label": "Spatial resolution (optional)",
       "type": "float",
-      "example": null,
+      "example": 0.008833,
       "weight": 6
     },
     "data>loadFromStac.yml@42|resampling": {

--- a/pipelines/zonal_statistics.json
+++ b/pipelines/zonal_statistics.json
@@ -225,7 +225,7 @@
       "weight": 7
     },
     "data>loadFromStac.yml@25|spatial_res": {
-      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long).",
+      "description": "Integer, spatial resolution of the rasters in the same units as the coordinate reference system (meters for projected reference systems and degrees for reference systems in lat long). \n\nIf this is left blank it will use the native resolution of the rasters. \n\nIf the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.",
       "label": "Spatial resolution (optional)",
       "type": "float",
       "example": 1000,

--- a/scripts/data/loadFromStac.R
+++ b/scripts/data/loadFromStac.R
@@ -7,8 +7,6 @@ library("sf")
 library("lubridate")
 library("stars")
 library("terra")
-# sf_use_s2(FALSE)
-print(outputFolder)
 
 input <- biab_inputs()
 
@@ -60,7 +58,7 @@ if (grepl("chelsa", input$collections_items[1], ignore.case = TRUE) && (!is.null
 coord <- st_crs(CRS)
 # Load the CRS object
 
-if (!is.null(CRS) & !is.null(input$spatial_res)) {
+if (!is.null(CRS) && !is.null(input$spatial_res)) {
   # Check for inconsistencies between CRS type and resolution
   if (st_is_longlat(coord) && input$spatial_res > 1) {
     biab_error_stop("CRS is in degrees and resolution is in meters.")
@@ -178,23 +176,20 @@ for (coll_it in collections_items) { # Loop through input array
     if (is.null(input$spatial_res)) {
       resolution <- res(r)
       resolution <- resolution[[1]]
+      if (!is.null(CRS)) {
+        # Check for inconsistencies between CRS type and resolution
+        if (st_is_longlat(coord) && resolution > 1) {
+          biab_error_stop("CRS is in degrees and resolution is in meters.")
+        }
+
+        if (st_is_longlat(coord) == FALSE && resolution < 1) {
+          biab_error_stop("CRS is in meters and resolution is in degrees.")
+        }
+      }
     } else {
       resolution <- as.numeric(input$spatial_res)
     }
     print(resolution)
-
-if (!is.null(CRS) && is.null(input$spatial_res)) {
-
-  # Check for inconsistencies between CRS type and resolution
-  if (st_is_longlat(coord) && resolution > 1) {
-    biab_error_stop("CRS is in degrees and resolution is in meters.")
-  }
-
-  if (st_is_longlat(coord) == FALSE && resolution < 1) {
-    biab_error_stop("CRS is in meters and resolution is in degrees.")
-  }
-
-}
 
     # Make empty raster with desired resolution and extent
     empty_raster <- rast(xmin = bounding_box[1], xmax = bounding_box[3], ymin = bounding_box[2], ymax = bounding_box[4], resolution = resolution, crs = srs.cube)
@@ -269,13 +264,12 @@ if (!is.null(CRS) && is.null(input$spatial_res)) {
       print(spatial.res)
 
       if (st_is_longlat(coord) == FALSE && spatial.res < 1) {
-      biab_error_stop("CRS is in meters and resolution is in degrees.")
+        biab_error_stop("CRS is in meters and resolution is in degrees.")
       }
 
       if (st_is_longlat(coord) && spatial.res > 1) {
-      biab_error_stop("CRS is in degrees and resolution is in meters.")
+        biab_error_stop("CRS is in degrees and resolution is in meters.")
       }
-
     } else {
       spatial.res <- input$spatial_res
     }

--- a/scripts/data/loadFromStac.R
+++ b/scripts/data/loadFromStac.R
@@ -59,17 +59,6 @@ if (grepl("chelsa", input$collections_items[1], ignore.case = TRUE) && (!is.null
 }
 coord <- st_crs(CRS)
 # Load the CRS object
-if (!is.null(CRS) && is.null(input$spatial_res)) {
-
-  if (!st_is_longlat(coord)) {
-    biab_error_stop(
-      "A projected CRS was supplied but no spatial resolution was provided. 
-      The default resolution (0.00833 degrees) can only be used with geographic CRSs."
-    )
-
-  }
-
-}
 
 if (!is.null(CRS) & !is.null(input$spatial_res)) {
   # Check for inconsistencies between CRS type and resolution
@@ -193,6 +182,19 @@ for (coll_it in collections_items) { # Loop through input array
       resolution <- as.numeric(input$spatial_res)
     }
     print(resolution)
+
+if (!is.null(CRS) && is.null(input$spatial_res)) {
+
+  # Check for inconsistencies between CRS type and resolution
+  if (st_is_longlat(coord) && resolution > 1) {
+    biab_error_stop("CRS is in degrees and resolution is in meters.")
+  }
+
+  if (st_is_longlat(coord) == FALSE && resolution < 1) {
+    biab_error_stop("CRS is in meters and resolution is in degrees.")
+  }
+
+}
 
     # Make empty raster with desired resolution and extent
     empty_raster <- rast(xmin = bounding_box[1], xmax = bounding_box[3], ymin = bounding_box[2], ymax = bounding_box[4], resolution = resolution, crs = srs.cube)

--- a/scripts/data/loadFromStac.R
+++ b/scripts/data/loadFromStac.R
@@ -59,6 +59,18 @@ if (grepl("chelsa", input$collections_items[1], ignore.case = TRUE) && (!is.null
 }
 coord <- st_crs(CRS)
 # Load the CRS object
+if (!is.null(CRS) && is.null(input$spatial_res)) {
+
+  if (!st_is_longlat(coord)) {
+    biab_error_stop(
+      "A projected CRS was supplied but no spatial resolution was provided. 
+      The default resolution (0.00833 degrees) can only be used with geographic CRSs."
+    )
+
+  }
+
+}
+
 if (!is.null(CRS) & !is.null(input$spatial_res)) {
   # Check for inconsistencies between CRS type and resolution
   if (st_is_longlat(coord) && input$spatial_res > 1) {

--- a/scripts/data/loadFromStac.yml
+++ b/scripts/data/loadFromStac.yml
@@ -45,7 +45,7 @@ inputs:
   spatial_res:
     label: Spatial resolution
     description: Integer, spatial resolution of the rasters in the same units as the coordinate reference system
-      (meters for projected reference systems and degrees for reference systems in lat long). If this is left blank it will use the native resolution of the rasters. If the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.
+      (meters for projected reference systems and degrees for reference systems in lat long). If this is left blank it will attempt to use the native resolution of the rasters, however the input CRS units must match the units of the native resolution. If the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.
     type: float
     example: 0.00833
   resampling:

--- a/scripts/data/loadFromStac.yml
+++ b/scripts/data/loadFromStac.yml
@@ -45,9 +45,9 @@ inputs:
   spatial_res:
     label: Spatial resolution
     description: Integer, spatial resolution of the rasters in the same units as the coordinate reference system
-      (meters for projected reference systems and degrees for reference systems in lat long). This input may be blank when using ESPG:4326.
+      (meters for projected reference systems and degrees for reference systems in lat long). If this is left blank it will use the native resolution of the rasters. If the spatial resolution is coarser than the native resolution of the rasters, the layers will be resampled with the resampling method chosen below.
     type: float
-    example: NULL
+    example: 0.00833
   resampling:
     label: Resampling method
     description: Resampling method used when rescaling and/or reprojecting the raster layers. Will be ignored if no resampling occurs.


### PR DESCRIPTION
Now it produces an error if they don't match and if you leave it as null it produces an error and tells you to only leave it as null if it is in degrees

Closes #340 