### PR TITLE
Conda pack environment variables

### DIFF
--- a/runner-sample.env
+++ b/runner-sample.env
@@ -53,6 +53,13 @@ RECAPTCHA_SERVER_KEY=
 # this option can be set to true.
 #BLOCK_RUNS=true
 
+# Optional: Enable to use conda-pack, recommended for Kubernetes and HPC enabled installations.
+# The conda-packs will be fetched in priority from CONDA_PACK_URL. 
+# If not present, they will be computed locally and saved to the output/_envs folder.
+# This will remove the need for re-computing the environments each run when the containers are ephemeral.
+CONDA_PACK_ENABLED=false
+CONDA_PACK_URL=https://object-arbutus.alliancecan.ca/swift/v1/3857940e33774dca8ae21e4999fe402e/conda-pack/
+
 ################
 ##### HPC ######
 ################


### PR DESCRIPTION
This PR adds the necessary environment variables to use conda-pack, see PR https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/pull/412.

Enabling conda-pack is recommended for Kubernetes, CWL, and HPC (not yet supported) but not for regular use on a single machine.