### PR TITLE
Conda Pack creation - github workflow - based on edge

### DIFF
--- a/.github/scripts/extractCondaEnvs.py
+++ b/.github/scripts/extractCondaEnvs.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Writes <condaEnvYmlDir>/<envName>.yml for every scripts/**/*.yml that has a
+# top-level `conda:` key, using the same envName transform as ScriptStep.kt
+# (relative path from scripts root, '/' -> '__', ' ' -> '_', strip .yml suffix).
+# Prints one envName per line.
+#
+# Usage: extractCondaEnvs.py <scriptsRoot> <condaEnvYmlDir>
+
+import pathlib
+import sys
+
+import yaml
+
+
+def main(scriptsRootArg: str, condaEnvYmlDirArg: str) -> None:
+    scriptsRoot = pathlib.Path(scriptsRootArg)
+    condaEnvYmlDir = pathlib.Path(condaEnvYmlDirArg)
+    condaEnvYmlDir.mkdir(parents=True, exist_ok=True)
+
+    for ymlFile in sorted(scriptsRoot.rglob("*.yml")):
+        doc = yaml.safe_load(ymlFile.read_text()) or {}
+        condaSection = doc.get("conda")
+        if not condaSection:
+            continue
+
+        envName = str(ymlFile.relative_to(scriptsRoot)).replace("/", "__").replace(" ", "_")
+        envName = envName.removesuffix(".yml")
+        condaSection["name"] = envName
+
+        (condaEnvYmlDir / f"{envName}.yml").write_text(yaml.dump(condaSection))
+        print(envName)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/.github/scripts/uploadAllCondaPacks.sh
+++ b/.github/scripts/uploadAllCondaPacks.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Build, conda-pack and upload to S3 every conda environment used by BON in a Box
+# scripts, plus the two shared base environments (rbase, pythonbase).
+# Archives are tagged with the current pipeline-repo commit, and an unsuffixed
+# "latest" copy is also kept so condaEnvironment.sh's CONDA_PACK_URL download
+# path keeps working unmodified.
+# An environment is skipped entirely (no create/pack/upload) if its spec is
+# identical to what's already at s3://$S3_BUCKET/<envName>.yml.
+#
+# Env vars:
+#   SCRIPTS_ROOT        Path to pipeline-repo/scripts (required)
+#   CONDA_ENV_YML_DIR   Where extracted per-env yml specs are written (default: /conda-env-yml)
+#   WORK_DIR            Scratch dir for packed archives before upload (default: /tmp/conda-pack-upload)
+#   GIT_COMMIT          Commit hash to tag archives with (required)
+#   S3_BUCKET           Target bucket (default: conda-pack)
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / S3_ENDPOINT_URL   Read directly by s5cmd
+
+set -o pipefail
+
+scriptDir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+SCRIPTS_ROOT=${SCRIPTS_ROOT:?SCRIPTS_ROOT must be set}
+GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT must be set}
+CONDA_ENV_YML_DIR=${CONDA_ENV_YML_DIR:-/conda-env-yml}
+WORK_DIR=${WORK_DIR:-/tmp/conda-pack-upload}
+S3_BUCKET=${S3_BUCKET:-conda-pack}
+
+failedEnvs=()
+packedCount=0
+skippedCount=0
+
+function assertSuccess {
+    if [[ $? -ne 0 ]] ; then
+        echo -e "FAILED" ; exit 1
+    fi
+}
+
+# Compares envYmlPath against the previously uploaded s3://$S3_BUCKET/<envName>.yml
+# (if any). Mirrors the cmp-before-repacking idiom already used by
+# condaPackEnvironment.sh and condaEnvironment.sh, just backed by S3 instead of
+# a local file, since this script has no state across CI runs.
+function unchangedSincePreviousUpload {
+    envName=$1
+    envYmlPath=$2
+
+    prevYml="$WORK_DIR/$envName.prev.yml"
+    rm -f "$prevYml"
+    s5cmd cp "s3://$S3_BUCKET/tmp/$envName.yml" "$prevYml" > /dev/null 2>&1
+
+    unchanged=1
+    if [[ -f "$prevYml" ]] && cmp -s "$prevYml" "$envYmlPath"; then
+        unchanged=0
+    fi
+    rm -f "$prevYml"
+    return $unchanged
+}
+
+# Writes $CONDA_ENV_YML_DIR/<envName>.yml for every scripts/**/*.yml that has a
+# top-level `conda:` key. Prints one envName per line.
+# See extractCondaEnvs.py for the envName derivation (matches ScriptStep.kt).
+function extractPerScriptEnvs {
+    python3 "$scriptDir/extractCondaEnvs.py" "$SCRIPTS_ROOT" "$CONDA_ENV_YML_DIR"
+}
+
+# Packs one env to $WORK_DIR/<envName>.tar.gz, uploads commit-tagged + latest
+# copies to S3 alongside its yml, then cleans up.
+function packAndUpload {
+    envName=$1
+    envYmlPath=$2
+
+    if unchangedSincePreviousUpload "$envName" "$envYmlPath"; then
+        echo "Skipping $envName, unchanged since last upload."
+        skippedCount=$((skippedCount + 1))
+        return
+    fi
+
+    if ! mamba env list | grep -q " $envName "; then
+        echo "Creating conda environment $envName..."
+        mamba env create -y -n "$envName" -f "$envYmlPath"
+        if [[ $? -ne 0 ]] ; then
+            echo "    FAILED to create $envName."
+            failedEnvs+=("$envName")
+            return
+        fi
+    fi
+
+    echo "Packing conda environment $envName..."
+    mamba activate base ; assertSuccess
+    tar="$WORK_DIR/$envName.tar"
+    conda-pack --n-threads -1 --quiet -n "$envName" -o "$tar" --compress-level 0
+    if [[ $? -ne 0 ]] ; then
+        echo "    FAILED to pack $envName."
+        failedEnvs+=("$envName")
+        mamba deactivate # base
+        return
+    fi
+    pigz "$tar" ; assertSuccess
+    mamba deactivate # base
+
+    zip="$tar.gz"
+    yml="$WORK_DIR/$envName.yml"
+    cp "$envYmlPath" "$yml" ; assertSuccess
+
+    echo "Uploading $envName (commit $GIT_COMMIT)..."
+    taggedZip="s3://$S3_BUCKET/tmp/$envName-$GIT_COMMIT.tar.gz"
+    taggedYml="s3://$S3_BUCKET/tmp/$envName-$GIT_COMMIT.yml"
+    s5cmd cp "$zip" "$taggedZip" ; assertSuccess
+    s5cmd cp "$yml" "$taggedYml" ; assertSuccess
+
+    # Refresh the unsuffixed "latest" pointer via a server-side copy, so
+    # condaEnvironment.sh's CONDA_PACK_URL download path (which has no
+    # knowledge of the commit hash) keeps finding the current archive.
+    s5cmd cp "$taggedZip" "s3://$S3_BUCKET/tmp/$envName.tar.gz" ; assertSuccess
+    s5cmd cp "$taggedYml" "s3://$S3_BUCKET/tmp/$envName.yml" ; assertSuccess
+
+    rm -f "$zip" "$yml"
+    packedCount=$((packedCount + 1))
+
+    # Keep the base envs around, they are reused for every script without its own conda: section.
+    if [[ "$envName" != "rbase" && "$envName" != "pythonbase" ]]; then
+        mamba env remove -qy -n "$envName" > /dev/null 2>&1
+    fi
+}
+
+source /.bashrc
+mkdir -p "$CONDA_ENV_YML_DIR" "$WORK_DIR"
+
+echo "Packing base environments..."
+packAndUpload rbase /data/r-environment.yml
+packAndUpload pythonbase /data/python-environment.yml
+
+echo "Packing per-script environments..."
+while IFS= read -r envName; do
+    packAndUpload "$envName" "$CONDA_ENV_YML_DIR/$envName.yml"
+done < <(extractPerScriptEnvs)
+
+echo "Packed and uploaded $packedCount environment(s), skipped $skippedCount unchanged."
+if [[ ${#failedEnvs[@]} -gt 0 ]]; then
+    echo "FAILED environments: ${failedEnvs[*]}"
+    exit 1
+fi

--- a/.github/workflows/conda_pack_upload.yml
+++ b/.github/workflows/conda_pack_upload.yml
@@ -18,14 +18,6 @@ jobs:
       - name: Check out pipeline-repo
         uses: actions/checkout@v4
 
-      - name: Check out pipeline-engine (script-stubs)
-        uses: actions/checkout@v4
-        with:
-          repository: GEO-BON/bon-in-a-box-pipeline-engine
-          ref: pack-it-all ##CHANGE ONCE MERGED
-          path: pipeline-engine
-          sparse-checkout: script-stubs
-
       - name: Install s5cmd
         run: |
           curl -L "https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_linux_amd64.deb" -o s5cmd.deb
@@ -45,4 +37,4 @@ jobs:
           source /.bashrc
           mamba activate base
           GIT_COMMIT=$(git rev-parse --short HEAD)
-          ./pipeline-engine/script-stubs/system/uploadAllCondaPacks.sh
+          ./.github/scripts/uploadAllCondaPacks.sh

--- a/.github/workflows/conda_pack_upload.yml
+++ b/.github/workflows/conda_pack_upload.yml
@@ -42,4 +42,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ARBUTUS_S3_SECRET_ACCESS_KEY }}
           S3_ENDPOINT_URL: https://object-arbutus.alliancecan.ca
         run: |
-          GIT_COMMIT=$(git rev-parse --short HEAD) ./pipeline-engine/script-stubs/system/uploadAllCondaPacks.sh
+          source /.bashrc
+          mamba activate base
+          GIT_COMMIT=$(git rev-parse --short HEAD)
+          ./pipeline-engine/script-stubs/system/uploadAllCondaPacks.sh

--- a/.github/workflows/conda_pack_upload.yml
+++ b/.github/workflows/conda_pack_upload.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: GEO-BON/bon-in-a-box-pipeline-engine
+          ref: pack-it-all
           path: pipeline-engine
           sparse-checkout: script-stubs
 

--- a/.github/workflows/conda_pack_upload.yml
+++ b/.github/workflows/conda_pack_upload.yml
@@ -1,0 +1,44 @@
+name: Pack and upload conda environments
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/**/*.yml'
+
+jobs:
+  pack-and-upload:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/geo-bon/bon-in-a-box-pipelines/runner-conda:latest
+
+    steps:
+      - name: Check out pipeline-repo
+        uses: actions/checkout@v4
+
+      - name: Check out pipeline-engine (script-stubs)
+        uses: actions/checkout@v4
+        with:
+          repository: GEO-BON/bon-in-a-box-pipeline-engine
+          path: pipeline-engine
+          sparse-checkout: script-stubs
+
+      - name: Install s5cmd
+        run: |
+          curl -L "https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_linux_amd64.deb" -o s5cmd.deb
+          dpkg -i s5cmd.deb
+          rm s5cmd.deb
+
+      - name: Pack and upload all conda environments
+        env:
+          SCRIPTS_ROOT: ${{ github.workspace }}/scripts
+          CONDA_ENV_YML_DIR: /conda-env-yml
+          WORK_DIR: /tmp/conda-pack-upload
+          S3_BUCKET: conda-pack
+          AWS_ACCESS_KEY_ID: ${{ secrets.ARBUTUS_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ARBUTUS_S3_SECRET_ACCESS_KEY }}
+          S3_ENDPOINT_URL: https://object-arbutus.alliancecan.ca
+        run: |
+          GIT_COMMIT=$(git rev-parse --short HEAD) ./pipeline-engine/script-stubs/system/uploadAllCondaPacks.sh

--- a/.github/workflows/conda_pack_upload.yml
+++ b/.github/workflows/conda_pack_upload.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: GEO-BON/bon-in-a-box-pipeline-engine
-          ref: pack-it-all
+          ref: pack-it-all ##CHANGE ONCE MERGED
           path: pipeline-engine
           sparse-checkout: script-stubs
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ rosm.cache
 *.Rproj
 lib/
 
+# Python cache
+**/__pycache__/
+
 # R temporary files
 .Rproj.user
 .Rhistory

--- a/runner-sample.env
+++ b/runner-sample.env
@@ -53,6 +53,13 @@ RECAPTCHA_SERVER_KEY=
 # this option can be set to true.
 #BLOCK_RUNS=true
 
+# Optional: Enable to use conda-pack, recommended for Kubernetes and HPC enabled installations.
+# The conda-packs will be fetched in priority from CONDA_PACK_URL. 
+# If not present, they will be computed locally and saved to the output/_envs folder.
+# This will remove the need for re-computing the environments each run when the containers are ephemeral.
+CONDA_PACK_ENABLED=false
+CONDA_PACK_URL=https://object-arbutus.alliancecan.ca/swift/v1/3857940e33774dca8ae21e4999fe402e/conda-pack/
+
 ################
 ##### HPC ######
 ################

--- a/runner-sample.env
+++ b/runner-sample.env
@@ -57,7 +57,11 @@ RECAPTCHA_SERVER_KEY=
 ##### HPC ######
 ################
 # Configure the following HPC_ variables to connect to a High Performance Computer (HPC).
-# An SSH tunnel will be used to send jobs.
+# Using HPC-scaling is an optional feature to enhance performance for very large tasks.
+# This section is only relevant if you have access to a HPC, 
+# and want to send some BON in a Box tasks on it.
+#
+# An SSH tunnel will be used to send the jobs, so SSH access to an automation node is needed.
 # This has currently only been tested with the DRAC infrastructure.
 
 # Config file for the SSH connection to the HPC.
@@ -101,3 +105,62 @@ HPC_AUTO_CONNECT=true
 HPC_APPTAINER_VERSION=
 
 ###### END HPC ######
+
+
+##########################
+##### Cloud-scaling ######
+##########################
+
+# Configure the following K8S_ variables to run tasks on a Kubernetes cluster.
+# Using cloud-scaling is an optional feature to accept large volumes of tasks.
+# This section is only relevant if you have access to a Kubernetes cluster, and want to run BON in a Box on it.
+#
+# For more information on how to setup a kubernetes cluster,
+# please refer to the Kubernetes documentation at https://kubernetes.io/docs/home/
+
+# Refresh Kubernetes worker status automatically on script-server startup.
+# - true: attempt status refresh asynchronously when script server starts.
+# - false: status refresh starts only when /api/k8s/status or /api/k8s/prepare API is called.
+K8S_AUTO_CONNECT=false
+
+# ** This involves a few manual steps! **
+# Path to the kubeconfig file to connect to the Kubernetes cluster.
+# Needs to be edited with the docker network IP address.
+# 1. Run `docker network ls` to find the BON in a Box network
+# 2. Run `docker network inspect bon-in-a-box_default`
+# 3. Find the IP address of the gateway, such as `"Gateway": "172.18.0.1"`
+# 4. Copy the file from /etc/rancher/k3s/k3s.yaml
+# 5. Change ownership and permissions of the file: `sudo chown ubuntu:ubuntu k3s.yaml && chmod a+r k3s.yaml`
+# 6. Replace the IP address in that file with the gateway IP
+# 7. Set this K8S_CONFIG_PATH variable to point to the edited file.
+# 8. Create a file in /etc/rancher/k3s/config.yaml.d, with the following content
+#    tls-san:
+#      - "<IP address of the gateway"
+#      - "<IP address of the host, as found in openstack ui>"
+#K8S_CONFIG_PATH=
+
+# Shared host path mounted in worker nodes for BON in a Box output folder.
+# example: /mnt/biab-shared/pipeline-repo/output
+#K8S_SHARED_OUTPUT_HOST_PATH=
+
+# Shared host path mounted in worker nodes for scripts folder.
+# example: /mnt/biab-shared/pipeline-repo/scripts
+#K8S_SHARED_SCRIPTS_HOST_PATH=
+
+# Shared host path mounted in worker nodes for script stubs folder.
+# example: /mnt/biab-shared/pipeline-repo/.server/script-stubs
+#K8S_SHARED_SCRIPT_STUBS_HOST_PATH=
+
+# Shared host path mounted in worker nodes for userdata folder.
+# example: /mnt/biab-shared/pipeline-repo/userdata
+#K8S_SHARED_USERDATA_HOST_PATH=
+
+# Shared host path mounted in worker nodes for runner.env file.
+# example: /mnt/biab-shared/pipeline-repo/runner.env
+#K8S_SHARED_RUNNER_ENV_HOST_PATH=
+
+# Namespace used to create Kubernetes jobs.
+# If left blank, defaults to "default".
+K8S_NAMESPACE=
+
+###### END cloud-scaling ######

--- a/runners/conda/conda-dockerfile
+++ b/runners/conda/conda-dockerfile
@@ -9,11 +9,14 @@ RUN chmod a+w /data
 # Setting Time zone (necessary to install cmake, + will persist at runtime)
 ENV TZ=Etc/UTC
 
-# CMake needs to be installed in order to install R packages from github (at least it's the case for some dependency of Makurhini)
+# Install
+# - CURL, needed to download conda-pack environments from the specified URL
+# - pigz, for faster unzipping using multiple cores
+# - CMake, needs to be installed in order to install R packages from github (at least it's the case for some dependency of Makurhini)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -ex; \
     apt-get update; \
-    apt-get install -y --no-install-recommends cmake psmisc; \
+    apt-get install -y --no-install-recommends cmake psmisc curl pigz; \
     apt-get clean all;
 
 ## Mamba installation

--- a/runners/conda/conda-dockerfile
+++ b/runners/conda/conda-dockerfile
@@ -40,6 +40,9 @@ RUN set -ex; \
 # We need to create it and set the permissions.
 RUN mkdir /conda-env-yml && chmod a+w /conda-env-yml;
 
+# Add conda-pack to the base environment
+RUN mamba install -n base conda-pack
+
 # Load R base environment
 ADD ./r-environment.yml /data/r-environment.yml
 RUN mamba env create -f /data/r-environment.yml \

--- a/runners/conda/python-environment.yml
+++ b/runners/conda/python-environment.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - pystac
+  - pyyaml

--- a/scripts/SDM/runMaxent.yml
+++ b/scripts/SDM/runMaxent.yml
@@ -127,3 +127,7 @@ conda:
     - r-tidyselect
     - r-tidyverse
     - r-stringr
+compute:
+  hpc: false
+  mem: 24G
+  cpus-per-task: 12

--- a/scripts/data/load_polygons.yml
+++ b/scripts/data/load_polygons.yml
@@ -9,8 +9,6 @@ author:
   - name: Jory Griffith
     email: jory.griffith@mcgill.ca
     identifier: https://orcid.org/0000-0001-6020-6690
-lifecycle:
-  status: core
 inputs:
   polygon_type:
     label: Polygon type

--- a/scripts/externalScripts.yaml
+++ b/scripts/externalScripts.yaml
@@ -1,0 +1,4 @@
+CDSE:
+  LAI.udp:
+    name: Leaf Area Index
+    url: https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/obsgession/udp_obsgession_w23_lai/records/udp_obsgession_w23_lai.json

--- a/scripts/helloWorld/helloHPC.R.yml
+++ b/scripts/helloWorld/helloHPC.R.yml
@@ -46,7 +46,8 @@ outputs:
       This will not be printed if job times out.
     type: int
     example: 4
-hpc:
+compute:
+  hpc: true
   mem: 1G
   cpus-per-task: 1
   time: "00:03:00"

--- a/scripts/helloWorld/helloHPC.py
+++ b/scripts/helloWorld/helloHPC.py
@@ -7,7 +7,7 @@ seconds = data['seconds']
 fileIn = data['some_csv_file']
 
 # Validations
-if not os.path.exists(fileIn):
+if fileIn is None or not os.path.exists(fileIn):
   biab_error_stop(f"File '{fileIn}' does not exist.")
 
 # Partial output

--- a/scripts/helloWorld/helloHPC.py.yml
+++ b/scripts/helloWorld/helloHPC.py.yml
@@ -46,7 +46,8 @@ outputs:
       This will not be printed if job times out.
     type: int
     example: 4
-hpc:
+compute:
+  hpc: true
   mem: 1G
   cpus-per-task: 1
   time: "00:03:00"

--- a/scripts/helloWorld/helloHPCConda.yml
+++ b/scripts/helloWorld/helloHPCConda.yml
@@ -56,7 +56,8 @@ conda:
     - conda-forge
   dependencies:
     - libcxx
-hpc:
+compute:
+  hpc: true
   mem: 1G
   cpus-per-task: 1
   time: "00:03:00"

--- a/scripts/helloWorld/helloJuliaHPC.yml
+++ b/scripts/helloWorld/helloJuliaHPC.yml
@@ -68,7 +68,8 @@ references:
   - text: John Doe, The ins and outs of copy-pasting, CopyScience, Volume 71, Issue 5, May 2021, Pages 448–451
     doi: 10.1093/copysci/biab041
 
-hpc:
+compute:
+  hpc: true
   mem: 2G
   cpus-per-task: 1
   time: "00:03:00"

--- a/scripts/protconn_analysis/protconn_analysis.yml
+++ b/scripts/protconn_analysis/protconn_analysis.yml
@@ -164,3 +164,7 @@ references:
       UNEP-WCMC and IUCN (2026), Protected Planet: The World Database on
       Protected Areas (WDPA), Cambridge, UK: UNEP-WCMC and IUCN.
     doi: https://doi.org/10.34892/6fwd-af11
+
+compute:
+  mem: 25G
+  cpus-per-task: 4


### PR DESCRIPTION
In association with https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/pull/442

Proposed solution to generate conda packs. 

The Conda pack gets regenerated when a given script is merged to main. It contains the commit hash of the script at the moment of the merge. Another copy of the Conda pack without the commit ref is copied to assure compatibility with current CWL scripts (TBD).
