### PR TITLE
Protconn subenvironment

### DIFF
--- a/runners/conda/conda-dockerfile
+++ b/runners/conda/conda-dockerfile
@@ -54,20 +54,20 @@ RUN mkdir /.R && echo "MAKEFLAGS = -j4" > /.R/Makevars && chmod a+r /.R/Makevars
 RUN mkdir /root/.R && echo "MAKEFLAGS = -j" > /root/.R/Makevars
 
 
-RUN bash --login -c "mamba activate rbase \
-    && R -e ' \
-## ADD CRAN PACKAGES HERE (uncomment for packages not found in anaconda.org) \
-        # install.packages(c(\"CoordinateCleaner\", \
-        # ), repos=\"https://cloud.r-project.org/\"); \
-        # \
-## ADD GITHUB PACKAGES HERE (for packages not found in anaconda.org nor CRAN) \
-        devtools::install_github(\"connectscape/Makurhini\"); \
-    ' \
-    # Remove documentation files from /opt/conda/envs/rbase/lib/R/library \
-    # || true at the end just makes sure that this step doesn't fail the build if none were found \
-    && (find /opt/conda/envs/rbase/lib/R/library -name 'help' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true) \
-    && (find /opt/conda/envs/rbase/lib/R/library -name 'html' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true) \
-    && (find /opt/conda/envs/rbase/lib/R/library -name 'doc' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true)"
+# RUN bash --login -c "mamba activate rbase \
+#     && R -e ' \
+# ## ADD CRAN PACKAGES HERE (for packages not found in anaconda.org) \
+#         install.packages(c(\"...\", \"...\", \
+#         ), dependencies=FALSE, repos=\"https://cloud.r-project.org/\"); \
+#         \
+# ## ADD GITHUB PACKAGES HERE (for packages not found in anaconda.org nor CRAN) \
+#         remotes::install_github(\"...\", dependencies = FALSE); \
+#     ' \
+#     # Remove documentation files from /opt/conda/envs/rbase/lib/R/library \
+#     # || true at the end just makes sure that this step doesn't fail the build if none were found \
+#     && (find /opt/conda/envs/rbase/lib/R/library -name 'help' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true) \
+#     && (find /opt/conda/envs/rbase/lib/R/library -name 'html' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true) \
+#     && (find /opt/conda/envs/rbase/lib/R/library -name 'doc' -prune -type d | xargs -r -i -P 16 rm -r \"{}\" || true)"
 
 # Load python base environment
 ADD ./python-environment.yml /data/python-environment.yml

--- a/scripts/protconn_analysis/protconn_analysis.R
+++ b/scripts/protconn_analysis/protconn_analysis.R
@@ -1,3 +1,26 @@
+# These packages are not on Anaconda, so we install them from CRAN or GitHub
+biab_ensure_package(
+    "samc", # required by Makurhini
+    installer = function() {
+        install.packages(c("samc"), dependencies=FALSE); 
+    }
+)
+
+biab_ensure_package(
+    "graph4lg", # required by Makurhini
+    installer = function() {
+        install.packages(c("graph4lg"), dependencies=FALSE); 
+    }
+)
+
+biab_ensure_package(
+    "Makurhini",
+    installer = function() {
+        remotes::install_github("connectscape/Makurhini@1dc5bd3ce9f141656f058778eac0cb08a166269e", dependencies = FALSE)
+    }
+)
+
+
 # Script for analyzing ProtConn with the function
 packages_list <- list("sf", "terra", "tidyverse", "ggrepel", "rjson", "Makurhini", "PROJ")
 

--- a/scripts/protconn_analysis/protconn_analysis.yml
+++ b/scripts/protconn_analysis/protconn_analysis.yml
@@ -164,6 +164,55 @@ references:
       UNEP-WCMC and IUCN (2026), Protected Planet: The World Database on
       Protected Areas (WDPA), Cambridge, UK: UNEP-WCMC and IUCN.
     link: https://doi.org/10.34892/6fwd-af11
+conda:
+  channels:
+    - conda-forge
+  dependencies:
+    # Script dependencies
+    - r-ggrepel
+    - r-proj
+    - r-remotes
+    - r-rjson
+    - r-tidyverse
+    - r-units
+
+    # Makurhini 3.0 dependencies
+    - r-boot
+    - r-cpprouting
+    - r-data.table
+    - r-formattable
+    - r-furrr
+    - r-future
+    - r-gdistance
+    - r-ggplot2
+    - r-ggpubr
+    - r-googledrive
+    # - r-graph4lg is not available as a conda-forge package.
+    - r-igraph
+    - r-magrittr
+    - r-ps
+    - r-purrr
+    - r-rappdirs
+    - r-raster
+    - r-rlang
+    - r-rmapshaper
+    # - r-samc is not available as a conda-forge package.
+    - r-sf
+    - r-terra
+
+    # required by samc
+    - r-rcppeigen
+    - r-rcppthread
+
+    # required by graph4lg
+    - r-adegenet
+    - r-ecodist
+    - r-foreign
+    - r-hierfstat
+    - r-pegas
+    - r-spatstat.geom
+    - r-spatstat.linnet
+    - r-vegan
 
 compute:
   mem: 25G


### PR DESCRIPTION
Dedicated sub-environment for Makurhini.
GitHub installation in script but with all dependencies pre-installed from anaconda (except graph4lg and samc which are not available).

closes #381 
